### PR TITLE
signature on award creation form instead of user creation :heart:

### DIFF
--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -27,7 +27,9 @@ class AwardsController < ApplicationController
   # POST /awards
   # POST /awards.json
   def create
-    @award = Award.new(award_params)
+    current_user.signature ||= award_params['signature']
+
+    @award = Award.new(award_params.except('signature'))
 
     @award.granter = current_user
 
@@ -80,7 +82,7 @@ class AwardsController < ApplicationController
         #File.delete("#{Rails.root}/test.pdf")
         #File.delete("#{Rails.root}/TEST_FILE.png")
 
-        format.html { redirect_to @award, notice: 'Award was successfully created by'}
+        format.html { redirect_to @award, notice: 'Award was successfully created by' }
         format.json { render :show, status: :created, location: @award }
 
       else
@@ -115,19 +117,19 @@ class AwardsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_award
-      @award = Award.find(params[:id])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_award
+    @award = Award.find(params[:id])
+  end
 
-    def check_admin
-      if current_user.role == 'admin'
-        redirect_to root_path
-      end
+  def check_admin
+    if current_user.role == 'admin'
+      redirect_to root_path
     end
+  end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def award_params
-      params.require(:award).permit(:award_type, :employee_name, :employee_email, :"grant_date(2i)", :"grant_date(3i)", :"grant_date(1i)" )
-    end
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def award_params
+    params.require(:award).permit(:award_type, :employee_name, :employee_email, :"grant_date(2i)", :"grant_date(3i)", :"grant_date(1i)", :signature)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,6 +109,6 @@ class UsersController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation, :signature, :role_type)
+    params.require(:user).permit(:email, :name, :password, :password_confirmation, :role_type)
   end
 end

--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -5,6 +5,7 @@ class Award < ApplicationRecord
              class_name: "User"
 
   belongs_to :granter,
+             autosave: true,
              class_name: "User"
 
   VALID_AWARDS = ["Employee of the Month", "Employee of the Year", "Kudos"].freeze
@@ -40,8 +41,14 @@ class Award < ApplicationRecord
             presence: true
   validates :grant_date,
             presence: true
+  validates :signature,
+            presence: true
 
   # methods
+
+  def signature
+    granter&.signature
+  end
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,6 @@ end
             presence: true
   validates :password_salt,
             presence: true
-  validates :signature,
-            presence: {
-                if: "role_type == 'non_admin'"
-            }
 
   enum role_type: [:guest, :non_admin, :admin]
 

--- a/app/views/awards/_form.html.erb
+++ b/app/views/awards/_form.html.erb
@@ -42,12 +42,32 @@
     <%= f.text_field :employee_email %>
   </div><br>
 
-  <div class="panel panel-default">
+<% unless current_user.signature %>
+ <div id="signature_area">
+   <%= f.hidden_field :signature, class: 'signature_pad_input' %>
+   <div class="signature_pad">
+     <div class="signature_pad_body">
+       <canvas style="border:2px dashed #18BC9C"></canvas>
+     </div>
+
+     <div class="signature_pad_footer">
+       <div class="lead">
+         Sign above
+       </div>
+       <button type="button" class="btn btn-primary signature_pad_clear">Clear signature</button>
+     </div>
+   </div>
+ </div>
+<% end %>
+   <br>
+   <div class="actions">
+     <%= f.submit :submit, :class => 'btn btn-success signature_pad_save' %>
+   </div>
+
+  <br><br>
+
+   <div class="panel panel-default">
     <div class="panel-heading"><em>Your name and the current timestamp will be automatically associated with the award upon creation</em></div>
 </div>
-
-  <div class="actions">
-    <%= f.submit :submit, :class => 'btn btn-success signature_pad_save' %>
-  </div>
 
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -39,26 +39,10 @@
     <%= f.radio_button :role_type, 'non_admin' %>
     <%= label :role_type, 'Non-Admin' %>
   </div>
-  <br>
 
-  <div id="signature_area" style="display: none;">
-    <%= f.hidden_field :signature, class: 'signature_pad_input' %>
-    <div class="signature_pad">
-      <div class="signature_pad_body">
-        <canvas style="border:2px dashed teal"></canvas>
-      </div>
-
-      <div class="signature_pad_footer">
-        <div class="lead">
-          Sign above
-        </div>
-        <button type="button" class="btn btn-primary signature_pad_clear">Clear signature</button>
-      </div>
-    </div>
-  </div>
        <br>
   <div class="actions">
-    <%= f.submit :submit, :class => 'btn btn-success signature_pad_save' %>
+    <%= f.submit :submit, :class => 'btn btn-success' %>
   </div>
 <br>
 <% end %>


### PR DESCRIPTION
- Took off signature from user creation page
- Added hide signature form if the user making award already has a signature associated with it
